### PR TITLE
Config override per environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 1.0.0
 
+- BREAKING CHANGE: `PROJECT_CONFIG_FILE` now expects a filename (not a full path); use `PROJECT_CONFIG_DIR` for directory
 - BREAKING CHANGE: pushover's Notify method now requires a context when being called
 - BREAKING CHANGE: pushover's Notify returns DisabledError when pushover is disabled; logging removed from library
+- config: add environment-based config overlays via `PROJECT_CONFIG_DIR` and `PROJECT_CONFIG_ENV_VAR`
+- config: support multiple search directories (colon-separated `PROJECT_CONFIG_DIR`)
 - logger: add HandleErr method
 - upgrade Go to 1.26.2
 - upgrade dependencies to latest versions

--- a/README.md
+++ b/README.md
@@ -4,17 +4,34 @@ Core libraries for running a service
 
 ## config
 
-Configuration library that reads from a JSON file and supports 'hot reloading.'
+Configuration library that reads from JSON files and supports hot reloading with environment-based overlays.
 
-Location of the project's config JSON file is currently in the environmental variable `PROJECT_CONFIG_FILE`.
+### Environment Variables
 
-### JSON config file
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PROJECT_CONFIG_FILE` | Yes | — | Base config filename (e.g., `config.json`) |
+| `PROJECT_CONFIG_DIR` | No | `.` | Colon-separated list of directories to search for config files. First directory containing the base file wins. |
+| `PROJECT_CONFIG_ENV_VAR` | No | — | Name of the env var holding the environment name. Used to find the overlay file. |
+
+### Environment Overlays
+
+When `PROJECT_CONFIG_ENV_VAR` is set, the system reads the env var it names to determine the environment. An overlay file named `{base}_{env}.{ext}` is loaded on top of the base config.
+
+For example, with `PROJECT_CONFIG_FILE=config.json`, `PROJECT_CONFIG_ENV_VAR=DEPLOY_ENV`, and `DEPLOY_ENV=prod`:
+1. Searches for `config.json` in each directory listed in `PROJECT_CONFIG_DIR`
+2. Loads `config.json` as the base configuration
+3. If `config_prod.json` exists in the same directory, overlays it on top
+
+The overlay only needs to specify fields that differ from the base. Fields not present in the overlay retain their base values. This means `config.json` can be safely checked into source control with non-sensitive defaults, while `config_prod.json` holds environment-specific overrides.
+
+### JSON Config File
 
 The config file should be a JSON object with the top level keys being used as identifiers to the values (also JSON objects) which will be mapped to structs.
 
 #### Example
 
-JSON:
+Base config (`config.json`):
 
 ```json
 {
@@ -26,13 +43,25 @@ JSON:
 }
 ```
 
+Production overlay (`config_prod.json`):
+
+```json
+{
+  "app": {
+    "enabled": false
+  }
+}
+```
+
+Result: `app` struct has `name: "testing"`, `version: 1`, `enabled: false`.
+
 Go Code:
 
 ```go
 type app struct {
     Name    string `json:"name"`
     Ver     int    `json:"version"`
-    Enabled bool `json:"enabled"`
+    Enabled bool   `json:"enabled"`
 }
 
 func main() {
@@ -41,27 +70,17 @@ func main() {
 }
 ```
 
-### Caveat Emptor
+### Initializer Interface
 
-At this time, 'secrets' are written directly into the config file.
-It is _HIGHLY_ recommended that you DO NOT check it into source control.
-This will hopefully be addressed in the future.
+If your config struct implements `config.Initializer` (an `Initialize()` method), it will be called automatically after the config is loaded and again on each hot reload.
 
-Configuration allows for 'hot reloading.'
-If you change the configuration, it should be live within 15 seconds (currently this is not configurable).
+### Hot Reloading
 
-Hot Reloading things to know:
+Config files are checked for modifications every 15 seconds. If changes are detected, the config is reloaded. Errors during reload are logged and the previous configuration is retained.
 
-* if the config file is modified, changes will be reloaded in 15 seconds
-  * this is not editable
-  * you cannot disable this behavior
-* changing configs for objects that utilize an Initializer doesn't have the desired effect
-  * recommend not changing these settings
-    * if changes are made, restart the service
-    * bug report (entry in the TODO file) has been submitted
-* if the config is messed up (like breaking the JSON) it will cause the program to panic
-  * recommended not to use an editor that auto saves without linting
-  * bug report has been submitted
+Hot reloading can be disabled by calling `config.DisableHotReload()` before or after `LoadConfig`.
+
+Both the base file and environment overlay file are watched for changes.
 
 ## logger
 

--- a/config/main.go
+++ b/config/main.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,15 +27,22 @@ type (
 	configMapType  map[string][]byte
 	configPtrsType map[string]any
 	config         struct {
-		lastLoad    time.Time
-		configs     configMapType
-		configPtrs  configPtrsType
-		configFile  string
-		initialLoad bool
+		lastLoad       time.Time
+		configs        configMapType
+		configPtrs     configPtrsType
+		baseFile       string
+		envFile        string
+		envFileExisted bool
+		initialLoad    bool
 	}
 )
 
-const configFileString = "PROJECT_CONFIG_FILE"
+const (
+	configFileString   = "PROJECT_CONFIG_FILE"
+	configDirString    = "PROJECT_CONFIG_DIR"
+	configEnvVarString = "PROJECT_CONFIG_ENV_VAR"
+	pathSeparator      = ":"
+)
 
 //nolint:gochecknoglobals // cfg holds the configuration data, which should only be retrieved via getConfig()
 var (
@@ -53,19 +62,44 @@ func init() {
 	cfg.configPtrs = make(configPtrsType)
 	cfg.lastLoad = time.Now()
 	cfg.initialLoad = true
+	cfg.resolveConfigSources()
 }
 
-// getConfigFile returns the full path and filename of the configuration file
-func (c config) getConfigFile() string {
-	if c.configFile == "" {
-		// TODO: better way to get config file location
-		if filename := os.Getenv(configFileString); filename == "" {
-			panic(fmt.Errorf("env var %s is not set", configFileString))
-		} else {
-			c.configFile = filename
+func (c *config) resolveConfigSources() {
+	filename := os.Getenv(configFileString)
+	if filename == "" {
+		panic(fmt.Errorf("env var %s is not set", configFileString))
+	}
+
+	dirList := os.Getenv(configDirString)
+	if dirList == "" {
+		dirList = "."
+	}
+
+	for dir := range strings.SplitSeq(dirList, pathSeparator) {
+		candidate := filepath.Join(dir, filename)
+		if _, err := os.Stat(candidate); err == nil { //nolint:gosec // path from env var config
+			c.baseFile = candidate
+			break
 		}
 	}
-	return c.configFile
+
+	if c.baseFile == "" {
+		panic(fmt.Errorf("%s (%s) not found in directories: %s", configFileString, filename, dirList))
+	}
+
+	if envVarName := os.Getenv(configEnvVarString); envVarName != "" {
+		if env := os.Getenv(envVarName); env != "" {
+			ext := filepath.Ext(filename)
+			stem := strings.TrimSuffix(filename, ext)
+			envFilename := fmt.Sprintf("%s_%s%s", stem, env, ext)
+			c.envFile = filepath.Join(filepath.Dir(c.baseFile), envFilename)
+		}
+	}
+}
+
+func (c *config) getConfigFile() string {
+	return c.baseFile
 }
 
 func initializeIfSupported(v any) {
@@ -93,28 +127,25 @@ func getConfig() *config {
 	return cfg
 }
 
-func load() error {
-	lock.Lock()
-	defer func() {
-		cfg.lastLoad = time.Now()
-		lock.Unlock()
-	}()
-
-	rawData, err := os.ReadFile(cfg.getConfigFile())
+func readJSONFile(path string) (map[string]any, error) {
+	rawData, err := os.ReadFile(path) //nolint:gosec // path resolved from env var config
 	if err != nil {
-		return fmt.Errorf("unable to open config file (%s): %s", cfg.getConfigFile(), err)
+		return nil, fmt.Errorf("unable to open config file (%s): %s", path, err)
 	}
 
 	if !json.Valid(rawData) {
-		return fmt.Errorf("invalid JSON found in file (%s)", cfg.getConfigFile())
+		return nil, fmt.Errorf("invalid JSON found in file (%s)", path)
 	}
 
 	data := map[string]any{}
-	err = json.Unmarshal(rawData, &data)
-	if err != nil {
-		return fmt.Errorf("unable to unmarshal config file (%s): %s", cfg.getConfigFile(), err)
+	if err := json.Unmarshal(rawData, &data); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal config file (%s): %s", path, err)
 	}
 
+	return data, nil
+}
+
+func processConfigData(data map[string]any) error {
 	for key, value := range data {
 		valueJson, err := json.Marshal(value)
 		if err != nil {
@@ -127,11 +158,55 @@ func load() error {
 			continue
 		}
 
-		err = json.Unmarshal(valueJson, ptr)
-		if err != nil {
+		if err = json.Unmarshal(valueJson, ptr); err != nil {
 			return fmt.Errorf("unable to unmarshal pointer for %s: %s", key, err)
 		}
+	}
 
+	return nil
+}
+
+func loadEnvOverlay() error {
+	if cfg.envFile == "" {
+		return nil
+	}
+
+	_, statErr := os.Stat(cfg.envFile)
+	cfg.envFileExisted = statErr == nil
+
+	if !cfg.envFileExisted {
+		return nil
+	}
+
+	envData, err := readJSONFile(cfg.envFile)
+	if err != nil {
+		return err
+	}
+
+	return processConfigData(envData)
+}
+
+func load() error {
+	lock.Lock()
+	defer func() {
+		cfg.lastLoad = time.Now()
+		lock.Unlock()
+	}()
+
+	baseData, err := readJSONFile(cfg.baseFile)
+	if err != nil {
+		return err
+	}
+
+	if err := processConfigData(baseData); err != nil {
+		return err
+	}
+
+	if err := loadEnvOverlay(); err != nil {
+		return err
+	}
+
+	for _, ptr := range cfg.configPtrs {
 		initializeIfSupported(ptr)
 	}
 
@@ -153,6 +228,33 @@ func DisableHotReload() {
 	})
 }
 
+func shouldReload() bool {
+	baseInfo, err := os.Stat(cfg.baseFile)
+	if err != nil {
+		log.Printf("config reload: unable to stat file (%s): %s", cfg.baseFile, err)
+		return false
+	}
+
+	if baseInfo.ModTime().Sub(cfg.lastLoad) > 0 {
+		return true
+	}
+
+	if cfg.envFile != "" {
+		envInfo, err := os.Stat(cfg.envFile)
+		envExists := err == nil
+
+		if envExists && envInfo.ModTime().Sub(cfg.lastLoad) > 0 {
+			return true
+		}
+
+		if envExists != cfg.envFileExisted {
+			return true
+		}
+	}
+
+	return false
+}
+
 func startHotReload() {
 	if hotReloadDisabled.Load() {
 		return
@@ -170,12 +272,7 @@ func startHotReload() {
 					ticker.Stop()
 					return
 				case <-ticker.C:
-					fileInfo, err := os.Stat(cfg.getConfigFile())
-					if err != nil {
-						log.Printf("config reload: unable to stat file (%s): %s", cfg.getConfigFile(), err)
-						continue
-					}
-					if fileInfo.ModTime().Sub(cfg.lastLoad) > 0 {
+					if shouldReload() {
 						if err := load(); err != nil {
 							log.Printf("config reload: %s", err)
 						}

--- a/config/main.go
+++ b/config/main.go
@@ -41,7 +41,7 @@ const (
 	configFileString   = "PROJECT_CONFIG_FILE"
 	configDirString    = "PROJECT_CONFIG_DIR"
 	configEnvVarString = "PROJECT_CONFIG_ENV_VAR"
-	pathSeparator      = ":"
+	pathSeparator      = string(os.PathListSeparator)
 )
 
 //nolint:gochecknoglobals // cfg holds the configuration data, which should only be retrieved via getConfig()
@@ -96,10 +96,6 @@ func (c *config) resolveConfigSources() {
 			c.envFile = filepath.Join(filepath.Dir(c.baseFile), envFilename)
 		}
 	}
-}
-
-func (c *config) getConfigFile() string {
-	return c.baseFile
 }
 
 func initializeIfSupported(v any) {
@@ -302,7 +298,7 @@ func LoadConfig(name string, configStruct any) {
 	} else {
 		configData, ok := cfg.configs[name]
 		if !ok {
-			panic(fmt.Errorf("key (%s) not found in config file (%s)", name, cfg.getConfigFile()))
+			panic(fmt.Errorf("key (%s) not found in config file (%s)", name, cfg.baseFile))
 		}
 		err := json.Unmarshal(configData, &configStruct)
 		if err != nil {


### PR DESCRIPTION
The config package now uses three env vars instead of one:

  - PROJECT_CONFIG_FILE (required) — the config filename (e.g., config.json), no longer a full path
  - PROJECT_CONFIG_DIR (optional, defaults to .) — colon-separated list of directories to search; first directory
  containing the file wins
  - PROJECT_CONFIG_ENV_VAR (optional) — the name of an env var that holds the environment name (e.g., DEPLOY_ENV). If set,
   an overlay file like config_prod.json is loaded on top of the base config

  The overlay only needs fields that differ — json.Unmarshal into an already-populated struct naturally preserves
  unspecified fields. Both files are watched for hot-reload changes. Config sources are resolved once at init time.
